### PR TITLE
add docs and examples about selectors in wait

### DIFF
--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -50,7 +50,10 @@ var (
 		by providing the "delete" keyword as the value to the --for flag.
 
 		A successful message will be printed to stdout indicating when the specified
-        condition has been met. One can use -o option to change to output destination.`)
+        condition has been met. One can use -o option to change to output destination.
+	
+	        Note that when using selectors, this command will silently return without output
+                if the selector does not match on any label.`)
 
 	wait_example = templates.Examples(`
 		# Wait for the pod "busybox1" to contain the status condition of type "Ready".
@@ -58,7 +61,10 @@ var (
 
 		# Wait for the pod "busybox1" to be deleted, with a timeout of 60s, after having issued the "delete" command.
 		kubectl delete pod/busybox1
-		kubectl wait --for=delete pod/busybox1 --timeout=60s`)
+		kubectl wait --for=delete pod/busybox1 --timeout=60s
+
+		# Wait for deployments with label "category" equal to "web" OR "util" to be available
+		kubectl wait deployment -l "category in (web, util)" --for condition=available --timeout=60s`)
 )
 
 // WaitFlags directly reflect the information that CLI is gathering via flags.  They will be converted to Options, which


### PR DESCRIPTION
Added additional information about the behavior of the wait command when
no resource is matched. Also added an example to explain that this command
can also be used with sets when dealing with selectors.

**What this PR does / why we need it**:

I've seen many users in Slack very confused why the command "doesn't do anything" and silently returns. Or, some users think that to select multiple resources with multiple labels, they can use the comma separator (key1=val1,key2=val2) but in actuality they need the set operation (label1=key1 OR label2=key2) to select multiple resources with either of those labels.

For example: https://github.com/kubernetes/kubernetes/issues/65868

Ref: #66456

```release-note
NONE
```
